### PR TITLE
Add country details and bilingual search

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ This repository contains a simple Flask-based web application that shows weather
 
 ## Search by Country
 
-On the main page you can filter the table by entering a country name in the
-search field. Leaving the field blank will display all countries.
+On the main page you can filter the table by entering a country name in German
+or English. Leaving the field blank will display all countries. Clicking a
+country opens a detail page with additional information.
 
 ## Development in VS Code
 
@@ -28,10 +29,9 @@ search field. Leaving the field blank will display all countries.
 
 ## Sample Data
 
-The database is seeded with several example countries, including Germany,
-the USA, Spain, France, Italy, Canada, Brazil and Japan. On each page load the
-application randomizes the temperature and humidity values for demonstration
-purposes.
+The database is seeded with many countries and contains both the German and
+English names as well as a short info text. On each page load the application
+randomizes the temperature and humidity values for demonstration purposes.
 
 ## Note
 

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,16 +1,36 @@
 CREATE TABLE IF NOT EXISTS weather (
-    country VARCHAR(100) PRIMARY KEY,
+    code VARCHAR(2) PRIMARY KEY,
+    country VARCHAR(100),    -- German name
+    country_en VARCHAR(100), -- English name
     temperature INTEGER,
-    humidity INTEGER
+    humidity INTEGER,
+    info TEXT
 );
 
-INSERT INTO weather (country, temperature, humidity) VALUES
-('Deutschland', 20, 60),
-('USA', 25, 55),
-('Spanien', 28, 50),
-('Frankreich', 22, 65),
-('Italien', 26, 55),
-('Kanada', 18, 70),
-('Brasilien', 30, 75),
-('Japan', 24, 60)
-ON CONFLICT (country) DO NOTHING;
+INSERT INTO weather (code, country, country_en, temperature, humidity, info) VALUES
+('DE', 'Deutschland', 'Germany', 20, 60, 'Information über Deutschland'),
+('US', 'USA', 'United States', 25, 55, 'Information about the United States'),
+('ES', 'Spanien', 'Spain', 28, 50, 'Information über Spanien'),
+('FR', 'Frankreich', 'France', 22, 65, 'Information sur la France'),
+('IT', 'Italien', 'Italy', 26, 55, 'Informazioni sull\'Italia'),
+('CA', 'Kanada', 'Canada', 18, 70, 'Information about Canada'),
+('BR', 'Brasilien', 'Brazil', 30, 75, 'Informações sobre o Brasil'),
+('JP', 'Japan', 'Japan', 24, 60, 'Japan ni kansuru jōhō'),
+('GB', 'Großbritannien', 'United Kingdom', 21, 65, 'Information about the UK'),
+('AU', 'Australien', 'Australia', 23, 55, 'Information about Australia'),
+('IN', 'Indien', 'India', 27, 70, 'Information about India'),
+('CN', 'China', 'China', 29, 60, 'Information about China'),
+('RU', 'Russland', 'Russia', 19, 55, 'Information about Russia'),
+('MX', 'Mexiko', 'Mexico', 31, 65, 'Información sobre México'),
+('ZA', 'Südafrika', 'South Africa', 22, 50, 'Information about South Africa'),
+('AR', 'Argentinien', 'Argentina', 24, 55, 'Información sobre Argentina'),
+('NL', 'Niederlande', 'Netherlands', 20, 60, 'Informatie over Nederland'),
+('SE', 'Schweden', 'Sweden', 18, 65, 'Information om Sverige'),
+('CH', 'Schweiz', 'Switzerland', 19, 60, 'Informationen zur Schweiz'),
+('AT', 'Österreich', 'Austria', 21, 55, 'Informationen zu Österreich'),
+('PT', 'Portugal', 'Portugal', 26, 55, 'Informações sobre Portugal'),
+('PL', 'Polen', 'Poland', 20, 65, 'Informacje o Polsce'),
+('BE', 'Belgien', 'Belgium', 19, 60, 'Informations sur la Belgique'),
+('NO', 'Norwegen', 'Norway', 17, 70, 'Informasjon om Norge'),
+('DK', 'Dänemark', 'Denmark', 16, 65, 'Information om Danmark')
+ON CONFLICT (code) DO NOTHING;


### PR DESCRIPTION
## Summary
- extend database to include country codes, German/English names and info text
- support searching countries in German and English
- make each country clickable and show detail page

## Testing
- `python3 -m py_compile web/app.py`